### PR TITLE
Fix metadata null exceptions

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -104,7 +104,7 @@ public class AssignCommand extends Command {
         Amount updatedAmount = personToAssign.getAmount();
         Attendance updatedAttendance = personToAssign.getAtt();
         Sessions updatedSessions = personToAssign.getSess();
-        Metadata updatedMetadata = personToAssign.getMetadata();
+        Optional<Metadata> updatedMetadata = personToAssign.getMetadata();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
                 updatedRoles, updatedCcas, updatedAmount, updatedAttendance, updatedSessions, updatedMetadata);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -110,7 +110,9 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Role> updatedRoles = editPersonDescriptor.getRoles().orElse(personToEdit.getRoles());
         Set<Cca> updatedCcas = editPersonDescriptor.getCcas().orElse(personToEdit.getCcas());
-        Metadata updatedMetadata = editPersonDescriptor.getMetadata().orElse(personToEdit.getMetadata());
+        Optional<Metadata> updatedMetadata = editPersonDescriptor
+            .getMetadata()
+            .or(() -> personToEdit.getMetadata());
         Amount updatedAmount = personToEdit.getAmount();
         Attendance updatedAttendance = personToEdit.getAtt();
         Sessions updatedSessions = personToEdit.getSess();

--- a/src/main/java/seedu/address/logic/commands/OweCommand.java
+++ b/src/main/java/seedu/address/logic/commands/OweCommand.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AMOUNT;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -98,7 +99,7 @@ public class OweCommand extends Command {
         Amount updatedAmount = new Amount(amount.toString());
         Attendance updatedAttendance = personToOwe.getAtt();
         Sessions updatedSessions = personToOwe.getSess();
-        Metadata updatedMetadata = personToOwe.getMetadata();
+        Optional<Metadata> updatedMetadata = personToOwe.getMetadata();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRoles, updatedCcas,
                 updatedAmount, updatedAttendance, updatedSessions, updatedMetadata);

--- a/src/main/java/seedu/address/logic/commands/SetAttCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetAttCommand.java
@@ -105,7 +105,7 @@ public class SetAttCommand extends Command {
         Amount updatedAmount = personToAssign.getAmount();
         Attendance updatedAttendance = setAttDescriptor.getAtt().orElse(personToAssign.getAtt());
         Sessions updatedSessions = setAttDescriptor.getSess().orElse(personToAssign.getSess());
-        Metadata updatedMetaData = personToAssign.getMetadata();
+        Optional<Metadata> updatedMetaData = personToAssign.getMetadata();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
                 updatedRoles, updatedCcas, updatedAmount, updatedAttendance, updatedSessions, updatedMetaData);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -53,7 +54,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Role> roleList = ParserUtil.parseRoles(argMultimap.getAllValues(PREFIX_ROLE));
         Set<Cca> ccaList = ParserUtil.parseCcas(argMultimap.getAllValues(PREFIX_CCA));
-        Metadata metadata = ParserUtil.parseMetadata(argMultimap.getValue(PREFIX_METADATA).get());
+        Optional<String> metastring = argMultimap.getValue(PREFIX_METADATA);
+        Optional<Metadata> metadata = metastring.isPresent()
+            ? Optional.of(ParserUtil.parseMetadata(metastring.get()))
+            : Optional.empty();
         Amount amount = new Amount("0.0");
         Attendance attendance = new Attendance("0");
         Sessions sessions = new Sessions("0");

--- a/src/main/java/seedu/address/model/person/Metadata.java
+++ b/src/main/java/seedu/address/model/person/Metadata.java
@@ -9,6 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 
 public class Metadata {
+    public static final String NO_METADATA_STRING = "//NO METADATA//";
     public static final String MESSAGE_CONSTRAINTS =
             "Meta-data should only contain alphanumeric characters and spaces, and it should not be blank";
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -38,7 +38,7 @@ public class Person {
     private final Optional<Metadata> metadata;
 
     /**
-     * Every field must be present and not null exception optional fields
+     * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Role> roles, Set<Cca> ccas, Amount amount,
                   Attendance attendance, Sessions sessions, Optional<Metadata> metadata) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -34,13 +35,13 @@ public class Person {
     private final Attendance attendance;
     private final Sessions sessions;
 
-    private final Metadata metadata;
+    private final Optional<Metadata> metadata;
 
     /**
-     * Every field must be present and not null.
+     * Every field must be present and not null exception optional fields
      */
     public Person(Name name, Phone phone, Email email, Address address, Set<Role> roles, Set<Cca> ccas, Amount amount,
-                  Attendance attendance, Sessions sessions, Metadata metadata) {
+                  Attendance attendance, Sessions sessions, Optional<Metadata> metadata) {
         requireAllNonNull(name, phone, email, address, roles, ccas, amount, attendance, sessions, metadata);
 
         this.name = name;
@@ -53,6 +54,14 @@ public class Person {
         this.attendance = attendance;
         this.sessions = sessions;
         this.metadata = metadata;
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Person(Name name, Phone phone, Email email, Address address, Set<Role> roles, Set<Cca> ccas, Amount amount,
+                  Attendance attendance, Sessions sessions, Metadata metadata) {
+        this(name, phone, email, address, roles, ccas, amount, attendance, sessions, Optional.ofNullable(metadata));
     }
 
     /**
@@ -108,7 +117,7 @@ public class Person {
     /**
      * Returns the Metadata of the person.
      */
-    public Metadata getMetadata() {
+    public Optional<Metadata> getMetadata() {
         return metadata;
     }
 
@@ -186,7 +195,9 @@ public class Person {
                 .add("amount", amount)
                 .add("attendance", attendance)
                 .add("sessions", sessions)
-                .add("metadata", metadata)
+                .add("metadata", metadata
+                    .map(m -> m.toString())
+                    .orElse(Metadata.NO_METADATA_STRING))
                 .toString();
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -3,6 +3,7 @@ package seedu.address.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -77,7 +78,7 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
-        metadata = source.getMetadata().metadata;
+        metadata = source.getMetadata().map(m -> m.metadata).orElse(Metadata.NO_METADATA_STRING);
         amount = new JsonAdaptedAmount(source.getAmount());
         roles.addAll(source.getRoles().stream()
                 .map(JsonAdaptedRole::new)
@@ -143,14 +144,17 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(Amount.MESSAGE_CONSTRAINTS);
         }
 
+        boolean isNullMetadata = metadata.equals(Metadata.NO_METADATA_STRING);
         if (metadata == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     Metadata.class.getSimpleName()));
         }
-        if (!Metadata.isValidMetadata(metadata)) {
+        if (!isNullMetadata && !Metadata.isValidMetadata(metadata)) {
             throw new IllegalValueException(Metadata.MESSAGE_CONSTRAINTS);
         }
-        final Metadata modelMetadata = new Metadata(metadata);
+        final Optional<Metadata> modelMetadata = isNullMetadata
+            ? Optional.empty()
+            : Optional.of(new Metadata(metadata));
 
         final Amount modelAmount = amount.toModelType();
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -63,7 +63,7 @@ public class PersonCard extends UiPart<Region> {
         email.setText(person.getEmail().value);
         owe.setText("Owe: " + "$" + person.getAmount().value);
         attendance.setText("Attendance: " + person.getAtt().value + "/" + person.getSess());
-        metadata.setText(person.getMetadata().metadata);
+        metadata.setText(person.getMetadata().map(m -> m.metadata).orElse(""));
         person.getRoles().stream()
                 .sorted(Comparator.comparing(role -> role.roleName))
                 .forEach(role -> roles.getChildren().add(new Label(role.roleName)));

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -95,7 +95,9 @@ public class PersonTest {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", roles=" + ALICE.getRoles()
                 + ", CCAs=" + ALICE.getCcas() + ", amount=" + ALICE.getAmount() + ", attendance=" + ALICE.getAtt()
-                + ", sessions=" + ALICE.getSess() + ", metadata=" + ALICE.getMetadata() + "}";
+                + ", sessions=" + ALICE.getSess()
+                + ", metadata=" + ALICE.getMetadata().map(m -> m.toString()).orElse(Metadata.NO_METADATA_STRING)
+                + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -40,7 +40,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setAddress(person.getAddress());
         descriptor.setRoles(person.getRoles());
         descriptor.setCcas(person.getCcas());
-        descriptor.setMetadata(person.getMetadata());
+        descriptor.setMetadata(person.getMetadata().orElse(null));
     }
 
     /**

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.model.amount.Amount;
@@ -39,7 +40,7 @@ public class PersonBuilder {
     private Amount amount;
     private Attendance attendance;
     private Sessions sessions;
-    private Metadata metadata;
+    private Optional<Metadata> metadata;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -54,7 +55,7 @@ public class PersonBuilder {
         amount = new Amount(DEFAULT_AMOUNT);
         attendance = new Attendance(DEFAULT_ATTENDANCE);
         sessions = new Sessions(DEFAULT_SESSIONS);
-        metadata = new Metadata(DEFAULT_METADATA);
+        metadata = Optional.of(new Metadata(DEFAULT_METADATA));
     }
 
     /**
@@ -149,7 +150,7 @@ public class PersonBuilder {
      * Sets the {@code Metadata} of the {@code Person} that we are building.
      */
     public PersonBuilder withMetadata(String metadata) {
-        this.metadata = new Metadata(metadata);
+        this.metadata = Optional.of(new Metadata(metadata));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.cca.Cca;
+import seedu.address.model.person.Metadata;
 import seedu.address.model.person.Person;
 import seedu.address.model.roles.Role;
 
@@ -43,7 +44,10 @@ public class PersonUtil {
         person.getCcas().stream().forEach(
             c -> sb.append(PREFIX_CCA + c.ccaName + " ")
         );
-        sb.append(PREFIX_METADATA + person.getMetadata().metadata + " ");
+        sb.append(PREFIX_METADATA + person
+            .getMetadata()
+            .map(Metadata::toString)
+            .orElse(Metadata.NO_METADATA_STRING) + " ");
         return sb.toString();
     }
 


### PR DESCRIPTION
I attempted to manually find and handle null exceptions stemming from the optional argument in `AddCommand`, however, I soon gave up and decided to change `Person.metadata` into and `Optional` and let the type system tell me what to change.

Fixes #178 #153 #147 #142 #139 #137 #134 #126 