### PR TITLE
Fix removal of CCA when no more members in CCA

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCcaCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCcaCommand.java
@@ -84,8 +84,6 @@ public class DeleteCcaCommand extends Command {
                 model.setPerson(affectedPerson, affectedPerson.replaceCca(updatedCca));
                 result.append(String.format("Person affected: $%s\n", affectedPerson.getName()));
             });
-        // Remove Ccas
-        removedCcas.stream().distinct().forEach(model::deleteCca);
 
         // Update filteredlist to display the same people
         model.updateFilteredPersonList(p -> affectedPeople

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -45,6 +45,15 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     //// list overwrite operations
 
+    private void trimCcas() {
+        List<Person> allPerson = getPersonList();
+        getCcaList().stream().collect(Collectors.toList()).stream()
+            .filter(c -> allPerson
+                .stream()
+                .filter(p -> p.getCcas().contains(c)).count() == 0)
+            .forEach(c -> ccas.remove(c));
+    }
+
     /**
      * Replaces the contents of the person list with {@code persons}.
      * {@code persons} must not contain duplicate persons.
@@ -124,6 +133,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         Person newEditedPerson = editedPerson
             .replaceCca(ccas.getUniqueCcas(editedPerson.getCcas()));
         persons.setPerson(target, newEditedPerson);
+        trimCcas();
     }
 
     /**
@@ -132,6 +142,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+        trimCcas();
     }
     //// util methods
     @Override

--- a/src/main/java/seedu/address/ui/CcaCard.java
+++ b/src/main/java/seedu/address/ui/CcaCard.java
@@ -61,8 +61,28 @@ public class CcaCard extends UiPart<Region> {
 
         allRoles.forEach(r -> ccaRoleList
             .getChildren()
-            .add(generateRoleUi(r, ccaPersonel))
+            .add(generateRoleUi(r.roleName, ccaPersonel
+                .filtered(p -> !p
+                .getRoles()
+                .stream()
+                .noneMatch(o -> o.roleName.equals(r.roleName))
+                )
+                .stream()
+                .sorted((a, b) -> a.getName().fullName.compareTo(b.getName().fullName))
+                .collect(Collectors.toList())
+            ))
         );
+
+        List<Person> noRoles = ccaPersonel
+            .stream()
+            .filter(p -> p.getRoles().isEmpty())
+            .collect(Collectors.toList());
+
+        if (noRoles.size() != 0) {
+            ccaRoleList
+                .getChildren()
+                .add(generateRoleUi("No roles", noRoles));
+        }
     }
 
     private HBox generateRoleListElementUi(int idx, Person p) {
@@ -79,7 +99,7 @@ public class CcaCard extends UiPart<Region> {
         return hb;
     }
 
-    private VBox generateRoleUi(Role r, ObservableList<Person> ccaPersonel) {
+    private VBox generateRoleUi(String roleString, List<Person> rolePersonel) {
 
         VBox rb = new VBox();
         rb.getStyleClass().add("ccaRoleListBox");
@@ -87,18 +107,8 @@ public class CcaCard extends UiPart<Region> {
         // Add the role label
         Label l = new Label();
         l.getStyleClass().add("ccaRoleName");
-        l.setText(r.roleName + ":");
+        l.setText(roleString + ":");
         rb.getChildren().add(l);
-
-        // Get the people satisfying role
-        List<Person> rolePersonel = ccaPersonel.filtered(p -> !p
-            .getRoles()
-            .stream()
-            .noneMatch(o -> o.roleName.equals(r.roleName))
-            )
-            .stream()
-            .sorted((a, b) -> a.getName().fullName.compareTo(b.getName().fullName))
-            .collect(Collectors.toList());
 
         // Create box for rolePersonel list
         VBox b = new VBox();


### PR DESCRIPTION
In addition to removing a CCA when it has no more members, this pull also displays members of CCAs with no roles assigned.

![image](https://github.com/AY2324S2-CS2103T-W11-2/tp/assets/57632293/ecb5af85-df72-4c77-8d45-3432c858ed92)

Fixes #182, Fixes #175, Fixes #156