### PR TITLE
Fix the email domain bug

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -27,7 +27,8 @@ public class Email {
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE + "{2,}"
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + "{2,})*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + ")\\.[a-zA-Z]{2,}$"; // At least two chars
+    private static final String DOMAIN_LAST_PART_REGEX = "("
+            + DOMAIN_PART_REGEX + ")\\.[a-zA-Z]{2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -25,9 +25,9 @@ public class Email {
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
+    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE + "{2,}"
+            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + "{2,})*";
+    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + ")\\.[a-zA-Z]{2,}$"; // At least two chars
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
@@ -38,6 +38,7 @@ public class Email {
      *
      * @param email A valid email address.
      */
+
     public Email(String email) {
         requireNonNull(email);
         checkArgument(isValidEmail(email), MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/commands/OweCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OweCommandTest.java
@@ -1,15 +1,15 @@
 // Part of the code is adpatated from original AB3 Code. All credits and thanks to the original
 // CS2103T teaching team for this.
 package seedu.address.logic.commands;
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
@@ -37,9 +37,9 @@ public class OweCommandTest {
 
     @Test
     public void testGetIndex() {
-            Index expectedIndex = Index.fromOneBased(1);
-            OweCommand oweCommand = new OweCommand(expectedIndex, new Amount("10.00"));
-            assertEquals(expectedIndex, oweCommand.getIndex());
+        Index expectedIndex = Index.fromOneBased(1);
+        OweCommand oweCommand = new OweCommand(expectedIndex, new Amount("10.00"));
+        assertEquals(expectedIndex, oweCommand.getIndex());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/OweCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/OweCommandTest.java
@@ -1,6 +1,8 @@
 // Part of the code is adpatated from original AB3 Code. All credits and thanks to the original
 // CS2103T teaching team for this.
 package seedu.address.logic.commands;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -8,7 +10,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
@@ -32,6 +33,13 @@ public class OweCommandTest {
         OweCommand oweCommand = new OweCommand(outOfBoundIndex, amount);
 
         assertCommandFailure(oweCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void testGetIndex() {
+            Index expectedIndex = Index.fromOneBased(1);
+            OweCommand oweCommand = new OweCommand(expectedIndex, new Amount("10.00"));
+            assertEquals(expectedIndex, oweCommand.getIndex());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -57,9 +57,9 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
+        assertTrue(Email.isValidEmail("a@bc.com")); // minimal
+        assertTrue(Email.isValidEmail("test@localhost.com")); // alphabets only
+        assertTrue(Email.isValidEmail("123@145.com")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
@@ -68,10 +68,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@email.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@email.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -83,6 +83,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@email.com")));
     }
 }


### PR DESCRIPTION
Previous wrong email format 
```example@example```  is not support now

<img width="732" alt="Screenshot 2024-04-14 at 16 53 12" src="https://github.com/AY2324S2-CS2103T-W11-2/tp/assets/147591205/f33d9c97-7c92-4d8e-a031-4113dd27f12f">
